### PR TITLE
Drop deplicated api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Generate build number
       id: buildnumber
-      uses: einaregilsson/build-number@v2
+      uses: einaregilsson/build-number@v3
       with:
         token: ${{secrets.github_token}}
     - uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
- set-envが廃止されたので依存actionsをアップデート
    - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- actionsの自動アップデートをdependabotに指定