### PR TITLE
Add permissions for preparing strict settings of organization

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       issues: write
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
     - uses: actions/checkout@v2
     - name: Generate build number


### PR DESCRIPTION
@kogai 別途お知らせした件です。organization の設定で、GitHub Actions に与えるデフォルト値を以下のように変更します。

```
Read and write permissions
↓
Read repository contents permission
```

Permission を設定する必要があるため、その request になります。

[JasonEtco/create-an-issue](https://github.com/marketplace/actions/create-an-issue) はドキュメントに従いました。[einaregilsson/build-number](https://github.com/marketplace/actions/build-number-generator) は要らなさそう？間違っていたらすみません。😅

関連ドキュメント: [Workflow syntax for GitHub Actions - GitHub Docs > ](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
